### PR TITLE
fix: Update operatorGroups.ts

### DIFF
--- a/src/LineData.ts
+++ b/src/LineData.ts
@@ -25,16 +25,16 @@ export default class LineData {
 			// Special handling for JSX operators and attributes
 			if (operator === '<' || operator === '>' || operator === '/>') {
 				// Treat JSX tags as separate parts
-				const jsxPart = {
-					text: part,
-					length: part.length,
-					width: getPhysicalWidth(part),
-					operator: operator,
-					operatorWidth: getPhysicalWidth(operator),
-					operatorType: 'jsx',
-					decorationLocation: text.length,
-					decoratorChar: decoratorChar,
-				};
+				const jsxPart = new LinePart(
+					part,
+					part.length,
+					getPhysicalWidth(part),
+					operator,
+					getPhysicalWidth(operator),
+					'jsx',
+					text.length,
+					decoratorChar
+				);
 				parts.push(jsxPart);
 				continue;
 			}
@@ -46,7 +46,7 @@ export default class LineData {
 			const operatorType = operatorsGroup[operator];
 			const length = part.length;
 
-			parts.push({
+			const linePart = new LinePart(
 				text,
 				length,
 				width,
@@ -54,8 +54,9 @@ export default class LineData {
 				operatorWidth,
 				operatorType,
 				decorationLocation,
-				decoratorChar,
-			});
+				decoratorChar
+			);
+			parts.push(linePart);
 		}
 
 		// https://github.com/aNickzz/Align-Spaces/issues/13

--- a/src/operatorGroups.ts
+++ b/src/operatorGroups.ts
@@ -4,18 +4,19 @@ export const operatorGroups = {
 	comparison: ['===', '!==', '==', '!=', '>=', '<='],
 	comma: [],
 	index: ['.', '->', '=>'],
-	jsx: ['<', '>', '/>'],  // Add JSX-related operators
+	jsx: ['<', '>', '/>'],  // JSX-related operators
 	types: ['string', 'int', 'object', 'bool', 'array', 'securestring', 'secureObject'],
 };
 
-// Extend the operatorsGroup mapping
-(Object.keys(
-	operatorGroups
-) as (keyof typeof operatorGroups)[]).forEach((groupName) =>
-	operatorGroups[groupName].forEach(
-		(operator) => (operatorsGroup[operator] = groupName)
-	)
-);
+// Define the operatorsGroup mapping object
+export const operatorsGroup: { [operator: string]: keyof typeof operatorGroups } = {};
+
+// Populate the operatorsGroup with mappings
+(Object.keys(operatorGroups) as (keyof typeof operatorGroups)[]).forEach(groupName => {
+	operatorGroups[groupName].forEach(operator => {
+		operatorsGroup[operator] = groupName;
+	});
+});
 
 const operatorsSorted = [
 	...operatorGroups.assignment,
@@ -24,7 +25,7 @@ const operatorsSorted = [
 	...operatorGroups.comparison,
 	...operatorGroups.comma,
 	...operatorGroups.jsx,  // Add JSX operators to the sorted list
-].sort((a, b) => b.length - a.length); //naive regex escape
+].sort((a, b) => b.length - a.length); // naive regex escape
 
 export const getLineMatch = () =>
 	new RegExp(


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the initialization and population of the operatorsGroup mapping object to ensure correct mapping of operators to their respective groups.

Bug Fixes:
- Fix the initialization of the operatorsGroup mapping object to ensure it is properly defined and populated.

<!-- Generated by sourcery-ai[bot]: end summary -->