### PR TITLE
chore: Add PR prefix using Azure OpenAI

### DIFF
--- a/.github/workflows/auto-pr-prefix.yml
+++ b/.github/workflows/auto-pr-prefix.yml
@@ -1,0 +1,41 @@
+name: "Auto PR Prefix"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  auto-pr-prefix:
+    name: Add PR Prefix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch PR title
+        id: fetch_pr_title
+        run: echo "::set-output name=pr_title::$(jq -r .pull_request.title < $GITHUB_EVENT_PATH)"
+
+      - name: Fetch PR diff
+        id: fetch_pr_diff
+        run: echo "::set-output name=pr_diff::$(jq -r .pull_request.diff_url < $GITHUB_EVENT_PATH)"
+
+      - name: Call Azure OpenAI to get PR prefix
+        id: call_openai
+        run: |
+          curl -X POST "$AZURE_OPENAI_ENDPOINT" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer $AZURE_OPENAI_API_KEY" \
+          -d "{\"prompt\": \"Determine the PR prefix for the following diff: $(echo ${{ steps.fetch_pr_diff.outputs.pr_diff }})\n\nAvailable types:\n- feat: A new feature\n- fix: A bug fix\n- docs: Documentation only changes\n- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)\n- refactor: A code change that neither fixes a bug nor adds a feature\n- perf: A code change that improves performance\n- test: Adding missing tests or correcting existing tests\n- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)\n- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)\n- chore: Other changes that don't modify src or test files\n- revert: Reverts a previous commit\"}" \
+          -o response.json
+          echo "::set-output name=pr_prefix::$(jq -r .choices[0].text < response.json)"
+
+      - name: Update PR title with prefix
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --title "${{ steps.call_openai.outputs.pr_prefix }}: ${{ steps.fetch_pr_title.outputs.pr_title }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-pr-prefix.yml
+++ b/.github/workflows/auto-pr-prefix.yml
@@ -1,6 +1,7 @@
 name: "Auto PR Prefix"
 
 on:
+  workflow_dispatch:
   pull_request_target:
     types:
       - opened

--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ output blobStorageConnectionString string = blobStorageConnectionString
 This works by adjusting the width of the character.
 The source file is not changed, nor are extra characters shown in the browser (so auto-format will not try to undo the formatting).
 
+## New GitHub Action for PR Title Modification
+
+We have added a new GitHub action that uses Azure OpenAI to automatically add the appropriate PR prefix to pull request titles. This ensures that all PRs follow the required naming conventions.
+
+### Configuration
+
+To configure the Azure OpenAI credentials, follow these steps:
+
+1. Go to your repository on GitHub.
+2. Click on `Settings`.
+3. In the left sidebar, click on `Secrets and variables` and then `Actions`.
+4. Click on `New repository secret`.
+5. Add the following secrets:
+   - `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI endpoint.
+   - `AZURE_OPENAI_API_KEY`: Your Azure OpenAI API key.
+
 ## Known Issues
 
 - Rectangular selections are borked


### PR DESCRIPTION
Fixes #39

Add a new GitHub action to automatically add PR prefixes using Azure OpenAI.

* **New GitHub Action**:
  - Create `.github/workflows/auto-pr-prefix.yml` to fetch PR title and diff, call Azure OpenAI, and update PR title with the appropriate prefix.
  - Store Azure OpenAI endpoint credentials in repository secrets.

* **Documentation**:
  - Update `README.md` to include a section about the new GitHub action for PR title modification.
  - Add instructions on how to configure Azure OpenAI credentials.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/Align-Bicep/issues/39?shareId=f7497efb-7d17-4a81-ae3f-1b5dfe114fad).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a GitHub Action that utilizes Azure OpenAI to automatically prefix pull request titles, ensuring adherence to naming conventions. Update documentation to guide users on configuring the necessary credentials.

New Features:
- Introduce a new GitHub Action to automatically add prefixes to pull request titles using Azure OpenAI.

Documentation:
- Update README.md to include a section about the new GitHub Action for PR title modification and instructions on configuring Azure OpenAI credentials.

<!-- Generated by sourcery-ai[bot]: end summary -->