### PR TITLE
fix: tests fail to publish in GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
         run: sudo apt-get install -y xvfb
 
       - name: Run tests with xvfb
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm test
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test:ci
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: test-results.xml
+          path: ./test-results.xml

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "pretest": "yarn run compile && yarn run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./dist/test/runTest.js",
+    "test:ci": "mocha --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results.xml",
     "format": "prettier --write ."
   },
   "devDependencies": {
@@ -113,6 +114,7 @@
     "eslint": "^7.26.0",
     "glob": "^7.1.6",
     "mocha": "^10.7.3",
+    "mocha-junit-reporter": "^2.0.0",
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0"
   },


### PR DESCRIPTION
Fixes #45

Update GitHub Action to publish test results.

* **package.json**
  - Add `mocha-junit-reporter` to `devDependencies`.
  - Add a new script `test:ci` to run tests with `mocha-junit-reporter`.

* **.github/workflows/test.yml**
  - Change the `Run tests with xvfb` step to use the `test:ci` script.
  - Update the `Upload test results` step to use the correct path for the generated `test-results.xml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/Align-Bicep/issues/45?shareId=30bd4b3e-a1c3-4a48-8297-21cb73e87e5f).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the GitHub Action workflow to correctly publish test results by using `mocha-junit-reporter` and updating the path for the test results file.

CI:
- Update GitHub Action workflow to use a new script `test:ci` for running tests with `mocha-junit-reporter`.
- Correct the path for the `test-results.xml` file in the `Upload test results` step of the GitHub Action workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->