### PR TITLE
fix: tests fail to publish in GitHub action (#46)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
         run: sudo apt-get install -y xvfb
 
       - name: Run tests with xvfb
-        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test:ci
+        run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm test
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: ./test-results.xml
+          path: test-results.xml

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "pretest": "yarn run compile && yarn run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./dist/test/runTest.js",
-    "test:ci": "mocha --reporter mocha-junit-reporter --reporter-options mochaFile=./test-results.xml",
     "format": "prettier --write ."
   },
   "devDependencies": {
@@ -114,7 +113,6 @@
     "eslint": "^7.26.0",
     "glob": "^7.1.6",
     "mocha": "^10.7.3",
-    "mocha-junit-reporter": "^2.0.0",
     "typescript": "^4.1.3",
     "vscode-test": "^1.5.0"
   },


### PR DESCRIPTION
This reverts commit 56b2bfa23b5930e85207168c1c1af9b5eaf72a4c.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the GitHub Actions workflow to ensure tests are executed and results are uploaded correctly by adjusting the test command and result file path.

CI:
- Fix the GitHub Actions workflow to correctly run tests using 'npm test' instead of 'npm run test:ci'.
- Correct the path for uploading test results in the GitHub Actions workflow from './test-results.xml' to 'test-results.xml'.

<!-- Generated by sourcery-ai[bot]: end summary -->