### PR TITLE
Add alignment for 'from' statements in TypeScript

### DIFF
--- a/src/LineData.ts
+++ b/src/LineData.ts
@@ -40,6 +40,22 @@ export default class LineData {
         continue;
       }
 
+      // Special handling for 'from' keyword in import statements
+      if (operator === "from") {
+        const fromPart: LinePart = {
+          text: part,
+          length: part.length,
+          width: getPhysicalWidth(part),
+          operator: operator,
+          operatorWidth: getPhysicalWidth(operator),
+          operatorType: "import", // Explicitly set as 'import'
+          decorationLocation: text.length,
+          decoratorChar: decoratorChar,
+        };
+        parts.push(fromPart);
+        continue;
+      }
+
       // Existing logic for other operators
       const width = getPhysicalWidth(part);
       const operatorWidth = getPhysicalWidth(operator);

--- a/src/operatorGroups.ts
+++ b/src/operatorGroups.ts
@@ -19,6 +19,7 @@ export const operatorGroups = {
     "securestring",
     "secureObject",
   ], // Specific keywords for type categorization, including domain-specific types.
+  import: ["from"], // Added 'from' to the operatorGroups under a new group 'import'
 };
 
 /**
@@ -54,6 +55,7 @@ const operatorsSorted = [
   ...operatorGroups.comparison,
   ...operatorGroups.comma,
   ...operatorGroups.jsx,
+  ...operatorGroups.import, // Include 'from' in the sorted list of operators
 ].sort((a, b) => b.length - a.length);
 
 /**
@@ -72,7 +74,8 @@ export const getLineMatch = () =>
       .map(
         (operator) =>
           (operatorsGroup[operator] === "types" ||
-          operatorsGroup[operator] === "jsx"
+          operatorsGroup[operator] === "jsx" ||
+          operatorsGroup[operator] === "import" // Include 'from' in the regular expression
             ? operator
             : operator.replace(/(.)/g, "\\$1")) +
           (operatorsGroup[operator] === "binary" ? "(?=\\s)" : "")

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -62,4 +62,35 @@ suite("Bicep Test Suite", () => {
       "JSX should be split into five parts"
     );
   });
+
+  const case6 = "import Sidebar from './components/Sidebar';";
+  const test6 = LineData.fromString(case6);
+  test("Test Import Statements", () => {
+    assert.strictEqual(test6.prefix, "", "Import prefix should be empty");
+    assert.strictEqual(
+      test6.parts.length,
+      2,
+      "Import statement should be split into two parts"
+    );
+    assert.strictEqual(
+      test6.parts[0].text,
+      "import Sidebar ",
+      "First part of import statement should be 'import Sidebar '"
+    );
+    assert.strictEqual(
+      test6.parts[0].operator,
+      "from",
+      "First operator should be 'from'"
+    );
+    assert.strictEqual(
+      test6.parts[0].operatorType,
+      "import",
+      "First operator type should be 'import'"
+    );
+    assert.strictEqual(
+      test6.parts[1].text,
+      " './components/Sidebar';",
+      "Second part of import statement should be ' './components/Sidebar';'"
+    );
+  });
 });


### PR DESCRIPTION
Fixes #49

Add alignment for 'from' statements in TypeScript import statements.

* **src/operatorGroups.ts**
  - Add 'from' to the `operatorGroups` under a new group `import`.
  - Modify `getLineMatch` function to include 'from' in the regular expression.

* **src/LineData.ts**
  - Add special handling for 'from' keyword in import statements.
  - Update `fromString` method to handle 'from' as a keyword for splitting lines.

* **src/test/suite/extension.test.ts**
  - Add test cases to verify alignment of 'from' statements in TypeScript.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/Align-Bicep/issues/49?shareId=a5c7419e-f00f-483c-8ef3-15d050cb5761).