### PR TITLE
fix: restrict type operators to standalone words to avoid splitting i…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Run tests with xvfb
         run: xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm test
 
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-results
-          path: test-results.xml
+      # - name: Upload test results
+      #   if: always()
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: test-results
+      #     path: test-results.xml

--- a/src/operatorGroups.ts
+++ b/src/operatorGroups.ts
@@ -71,8 +71,9 @@ export const getLineMatch = () =>
     `(.*?(.))(${operatorsSorted
       .map(
         (operator) =>
-          (operatorsGroup[operator] === "types" ||
-          operatorsGroup[operator] === "jsx"
+          (operatorsGroup[operator] === "types"
+            ? `\\b${operator}\\b`
+            : operatorsGroup[operator] === "jsx"
             ? operator
             : operator.replace(/(.)/g, "\\$1")) +
           (operatorsGroup[operator] === "binary" ? "(?=\\s)" : "")


### PR DESCRIPTION
…dentifiers

## Summary by Sourcery

Bug Fixes:
- Add word boundaries around type operators in regex generation to prevent them from matching inside identifiers